### PR TITLE
Create API-Gateway server with basic E2E demo

### DIFF
--- a/controllers/auth.go
+++ b/controllers/auth.go
@@ -1,0 +1,22 @@
+package controllers
+
+import (
+	"api-gateway/models"
+	"github.com/gin-gonic/gin"
+	"net/http"
+)
+
+// LoginHandler is the handler for the login route.
+func LoginHandler(c *gin.Context) {
+	var credentials models.LoginRequest
+	if err := c.ShouldBindJSON(&credentials); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid input"})
+		return
+	}
+	// Simulate authentication.
+	if credentials.Username == "admin" && credentials.Password == "1234" {
+		c.JSON(http.StatusOK, gin.H{"message": "Login successful", "username": credentials.Username})
+	} else {
+		c.JSON(http.StatusUnauthorized, gin.H{"error": "password is 1234 don't be noob"})
+	}
+}

--- a/controllers/dashboard.go
+++ b/controllers/dashboard.go
@@ -1,0 +1,20 @@
+package controllers
+
+import (
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+)
+
+func GetDashboardData(c *gin.Context) {
+	data := gin.H{
+		"headers": []gin.H{
+			{"title": "Student Profile", "content": "Details about the student"},
+			{"title": "Courses", "content": "List of courses"},
+			{"title": "Grades", "content": "Student grades"},
+			{"title": "Tips", "content": "Useful academic tips"},
+		},
+	}
+
+	c.JSON(http.StatusOK, data)
+}

--- a/controllers/grades.go
+++ b/controllers/grades.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"github.com/BetterGR/grades-microservice/protos"
 	"google.golang.org/grpc/credentials/insecure"
-	"log"
+	"k8s.io/klog/v2"
 	"net/http"
 	"time"
 
@@ -38,8 +38,9 @@ func GetStudentGradesHandler(c *gin.Context, grpcClient protos.GradesServiceClie
 	defer cancel()
 
 	response, err := grpcClient.GetStudentCourseGrades(ctx, request)
+	logger := klog.FromContext(ctx)
 	if err != nil {
-		log.Printf("Error calling gRPC Grades Microservice: %v", err)
+		logger.Info("Error calling gRPC Grades Microservice: %v", err)
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to fetch grades"})
 
 		return

--- a/controllers/grades.go
+++ b/controllers/grades.go
@@ -1,0 +1,50 @@
+package controllers
+
+import (
+	"context"
+	"github.com/BetterGR/grades-microservice/protos"
+	"google.golang.org/grpc/credentials/insecure"
+	"log"
+	"net/http"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"google.golang.org/grpc"
+)
+
+var grpcClient protos.GradesServiceClient
+
+func InitGRPCClient() {
+	// Initialize the gRPC client connection.
+	conn, err := grpc.NewClient("localhost:50051", grpc.WithTransportCredentials(insecure.NewCredentials()))
+	if err != nil {
+		log.Fatalf("Failed to connect to Grades Microservice: %v", err)
+	}
+	grpcClient = protos.NewGradesServiceClient(conn)
+}
+
+// GetStudentGradesHandler handles REST requests and calls the gRPC Grades Microservice.
+func GetStudentGradesHandler(c *gin.Context) {
+	studentId := c.Param("studentId")
+	courseId := c.Param("courseId")
+
+	// Build gRPC request.
+	request := &protos.GetStudentCourseGradesRequest{
+		StudentId: studentId,
+		CourseId:  courseId,
+	}
+
+	// Call the gRPC server.
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+
+	response, err := grpcClient.GetStudentCourseGrades(ctx, request)
+	if err != nil {
+		log.Printf("Error calling gRPC Grades Microservice: %v", err)
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to fetch grades"})
+		return
+	}
+
+	// Send response to the client.
+	c.JSON(http.StatusOK, response.CourseGrades)
+}

--- a/controllers/grades.go
+++ b/controllers/grades.go
@@ -12,19 +12,18 @@ import (
 	"google.golang.org/grpc"
 )
 
-var grpcClient protos.GradesServiceClient
-
-func InitGRPCClient() {
+func InitGRPCClient(address string) (protos.GradesServiceClient, error) {
 	// Initialize the gRPC client connection.
-	conn, err := grpc.NewClient("localhost:50051", grpc.WithTransportCredentials(insecure.NewCredentials()))
+	conn, err := grpc.NewClient(address, grpc.WithTransportCredentials(insecure.NewCredentials()))
 	if err != nil {
-		log.Fatalf("Failed to connect to Grades Microservice: %v", err)
+		return nil, err
 	}
-	grpcClient = protos.NewGradesServiceClient(conn)
+
+	return protos.NewGradesServiceClient(conn), nil
 }
 
 // GetStudentGradesHandler handles REST requests and calls the gRPC Grades Microservice.
-func GetStudentGradesHandler(c *gin.Context) {
+func GetStudentGradesHandler(c *gin.Context, grpcClient protos.GradesServiceClient) {
 	studentId := c.Param("studentId")
 	courseId := c.Param("courseId")
 
@@ -42,6 +41,7 @@ func GetStudentGradesHandler(c *gin.Context) {
 	if err != nil {
 		log.Printf("Error calling gRPC Grades Microservice: %v", err)
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to fetch grades"})
+
 		return
 	}
 

--- a/middleware/cors.go
+++ b/middleware/cors.go
@@ -1,0 +1,18 @@
+package middleware
+
+import (
+	"github.com/gin-gonic/gin"
+)
+
+func CORSMiddleware() gin.HandlerFunc {
+	return func(c *gin.Context) {
+		c.Writer.Header().Set("Access-Control-Allow-Origin", "*")
+		c.Writer.Header().Set("Access-Control-Allow-Methods", "POST, GET, OPTIONS")
+		c.Writer.Header().Set("Access-Control-Allow-Headers", "Content-Type, Authorization")
+		if c.Request.Method == "OPTIONS" {
+			c.AbortWithStatus(204)
+			return
+		}
+		c.Next()
+	}
+}

--- a/models/user.go
+++ b/models/user.go
@@ -1,0 +1,6 @@
+package models
+
+type LoginRequest struct {
+	Username string `json:"username" binding:"required"`
+	Password string `json:"password" binding:"required"`
+}

--- a/src/main.go
+++ b/src/main.go
@@ -1,0 +1,24 @@
+package main
+
+import (
+	"api-gateway/controllers"
+	"api-gateway/middleware"
+
+	"github.com/gin-gonic/gin"
+)
+
+func main() {
+	// Initialize the gRPC client connection.
+	controllers.InitGRPCClient()
+
+	router := gin.Default()
+
+	router.Use(middleware.CORSMiddleware())
+
+	// Rest endpoints.
+	router.POST("/api/login", controllers.LoginHandler)
+	router.GET("/api/dashboard", controllers.GetDashboardData)
+	router.GET("/api/grades/:student_id/:courseId", controllers.GetStudentGradesHandler)
+
+	router.Run(":8080")
+}

--- a/src/main.go
+++ b/src/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"api-gateway/controllers"
 	"api-gateway/middleware"
+	"k8s.io/klog/v2"
 	"log"
 
 	"github.com/gin-gonic/gin"
@@ -13,10 +14,12 @@ const (
 )
 
 func main() {
+	// init klog
+	klog.InitFlags(nil)
 	// Initialize the gRPC client connection.
 	grpcClient, err := controllers.InitGRPCClient(address)
 	if err != nil {
-		log.Fatal(err)
+		log.Fatalf("Failed to initialize gRPC client, %v", err)
 	}
 	router := gin.Default()
 

--- a/src/main.go
+++ b/src/main.go
@@ -3,14 +3,21 @@ package main
 import (
 	"api-gateway/controllers"
 	"api-gateway/middleware"
+	"log"
 
 	"github.com/gin-gonic/gin"
 )
 
+const (
+	address = "localhost:50051"
+)
+
 func main() {
 	// Initialize the gRPC client connection.
-	controllers.InitGRPCClient()
-
+	grpcClient, err := controllers.InitGRPCClient(address)
+	if err != nil {
+		log.Fatal(err)
+	}
 	router := gin.Default()
 
 	router.Use(middleware.CORSMiddleware())
@@ -18,7 +25,9 @@ func main() {
 	// Rest endpoints.
 	router.POST("/api/login", controllers.LoginHandler)
 	router.GET("/api/dashboard", controllers.GetDashboardData)
-	router.GET("/api/grades/:student_id/:courseId", controllers.GetStudentGradesHandler)
+	router.GET("/api/grades/:student_id/:courseId", func(c *gin.Context) {
+		controllers.GetStudentGradesHandler(c, grpcClient)
+	})
 
 	router.Run(":8080")
 }


### PR DESCRIPTION
## Summary
- Created an API-Gateway server #1  based on gingonic that uses rest to communicate with Frontend Web-App and gRPC to communicate with backend microservices.
- E2E demo #2 : Wep App send rest API request to API-Gateway Server, API-Gateway server routes this request to grades-microservice via gRPC using proto message, grades-microservice respond with a proto message using gRPC to API-Gateway server, and then back to Web App.

## Related Issues
- Fixes #1 
- Fixes #2 